### PR TITLE
[ us-3126 -> master ] BlockingComponent and LoadingSpinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reperio/ui-components",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Reperio UI Component Library",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/components/BlockingComponent.tsx
+++ b/src/components/BlockingComponent.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import LoadingSpinner from './LoadingSpinner';
+
+export class BlockingComponent extends React.Component<{readyToLoad: boolean}> {
+    render() {
+        if (this.props.readyToLoad) {
+            return this.props.children;
+        } else {
+            return (<LoadingSpinner />);
+        }
+    }
+}

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,40 @@
+import React, {CSSProperties} from "react";
+
+const topDivStyle: CSSProperties = {
+    position: "fixed",
+    top: 0,
+    left: 0,
+    height: "100%",
+    width: "100%",
+    display: "table",
+    backgroundColor: "rgba(255, 255, 255, 0.5)",
+    zIndex: 10000
+};
+
+const secondDivStyle: CSSProperties = {
+    display: "table-cell",
+    verticalAlign: "middle"
+};
+
+const thirdDivStyle: CSSProperties = {
+    width: "100px",
+    height: "100px",
+    margin: "auto"
+};
+
+const imgStyle: CSSProperties = {
+    width: "100%",
+    height: "100%"
+};
+
+const loadingSpinner = (props: any) => (
+    <div style={topDivStyle}>
+        <div style={secondDivStyle}>
+            <div style={thirdDivStyle}>
+                <div style={imgStyle} className="loading" />
+            </div>
+        </div>
+    </div>
+);
+
+export default loadingSpinner;

--- a/src/components/PhoneInput.tsx
+++ b/src/components/PhoneInput.tsx
@@ -22,7 +22,6 @@ const fullWidthStyle = {
 
 const PhoneInput: React.SFC<PhoneInputProps> = props => {
     let style = props.style ? { ...props.style } : {};
-    console.log(props.meta);
 
     if (props.meta && props.meta.touched && props.meta.error) {
         style.borderColor = 'red';

--- a/src/components/Picker.tsx
+++ b/src/components/Picker.tsx
@@ -24,8 +24,6 @@ const Picker: React.SFC<PickerProps> = props => {
         style.borderColor = 'red';
     }
 
-    console.log(props.meta);
-
     return <>
             <Select
                 value={props.pickerValue !=  null ? props.pickerValue : props.value}


### PR DESCRIPTION
Adding `BlockingComponent` that takes a boolean variable and displays a loading spinner while false, and displays all the component's children when true.

Currently going to be used in Managed IT to block page loading until `selectedOrganization` is verified to be accurate or not from persisted state.