### PR TITLE
us-3801 - Organization selection view is not correct in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reperio/ui-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Reperio UI Component Library",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1315,7 +1315,7 @@ div &.open &.#{$namespace}-applications-container > .#{$namespace}-applications 
     padding: 10px;
     box-shadow: none;
     border-radius: 0;
-    border: 5px solid transparent;
+    border: 5px solid;
     border-image: url("../assets/rio-slider-colorband1.png") 5 stretch;
     border-top: 0;
     border-left: 0;


### PR DESCRIPTION
This fixes the colored bar in the drop down from not being visible in Safari.