### PR TITLE
v1.5.2 adding exposing loading prop for Grid component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reperio/ui-components",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Reperio UI Component Library",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -38,7 +38,7 @@ class Grid extends React.Component<GridProps, State> {
             getTrProps={this.props.rowClick}
             pages={this.props.pages}
             onFetchData={this.bounced}
-            loading={this.state.loading}
+            loading={this.state.loading || this.props.loading}
             />
     }
 }
@@ -54,6 +54,7 @@ interface GridProps {
     rowClick?: any,
     pageSizeOptions?: number[]
     onFetchData?(page: number, pageSize: number, sorted: any, filtered: any): Promise<State>;
+    loading?: boolean;
 }
 
 interface State {


### PR DESCRIPTION
Exposing `loading` so an outside state property can tell the grid when to display the internal "Loading..." graphic, but making it load based on either the prop or internal state, so both can control it.